### PR TITLE
bump postgres version

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,2 +1,2 @@
 export * as kysely from 'https://esm.sh/kysely@0.17.1/dist/esm/index-nodeless.js';
-export * as postgres from 'https://deno.land/x/postgres@v0.15.0/mod.ts';
+export * as postgres from 'https://deno.land/x/postgres@v0.17.0/mod.ts';


### PR DESCRIPTION
Hello! I was having connection issues like the one below that are magically fixed when I bump to 0.17.0 for deno.land/x/postgres

```
TLS connection failed with message: invalid peer certificate contents: invalid peer certificate: UnknownIssuer
Defaulting to non-encrypted connection
error: Uncaught PostgresError: password authentication failed for user "postgres"
        throw new PostgresError(parseNoticeMessage(maybe_sasl_final));
```